### PR TITLE
workflows: build_and_deploy: Filter on tags

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,9 +1,10 @@
 name: 'Deploy on master merge'
 
 on:
-  pull_request:
-    branches: [ master ]
-    types: [closed]
+  push:
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+\+?r?e?v?[0-9]?
+      - 20[0-9][0-9].[0-1]?[1470].[0-9]+
 
     # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -16,14 +17,17 @@ jobs:
       boards: ${{ steps.list-boards.outputs.boards }}
     steps:
       - uses: actions/checkout@v3
+        if: startsWith( github.ref, 'refs/tags/')
 
       - name: 'Fetch latest tag'
         id: get-latest-tag
         uses: "actions-ecosystem/action-get-latest-tag@v1"
+        if: startsWith( github.ref, 'refs/tags/')
 
       - name: 'Set tag'
         id: set-tag
         run: echo "::set-output name=tag::${{ steps.get-latest-tag.outputs.tag }}"
+        if: startsWith( github.ref, 'refs/tags/')
 
       - name: 'Fetch all boards'
         id: list-boards
@@ -46,6 +50,7 @@ jobs:
 
   deploy:
     needs: fetch
+    if: contains(needs.check.outputs.status, 'success')
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.fetch.outputs.boards)}}


### PR DESCRIPTION
Only deploy when a tag for either a rolling or ESR release is created
by versionbot.

Changelog-entry: Filter on tags on build and deploy workflow
Signed-off-by: Alex Gonzalez <alexg@balena.io>